### PR TITLE
Add in option to retrieve watchers of an issue

### DIFF
--- a/config.template.ts
+++ b/config.template.ts
@@ -16,7 +16,8 @@ export const JIRA = {
   SPRINTINFO_CUSTOM_FIELD: 'customfield_10103',
   //reference to an epic as key e.g.: `PLAT-76`
   EPIC_REF_CUSTOM_FIELD: 'customfield_10006',
-  EPIC_TITLE_CUSTOM_FIELD: 'customfield_10003'
+  EPIC_TITLE_CUSTOM_FIELD: 'customfield_10003',
+  RETRIEVE_WATCHERS: false,
 };
 
 export const CLUBHOUSE = {

--- a/src/jira/jira-extraction.ts
+++ b/src/jira/jira-extraction.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import jira from './jiraApi';
+import { JIRA } from '../../config'; 
 
 const ensureDataDirExists = () => {
   if (!fs.existsSync(__dirname + '/../../data')) {
@@ -28,7 +29,16 @@ export const downloadAllIssues = async () => {
   while (true) {
     let startAt = collectedIssues.length;
     let response = await jira.searchJira('', {fields: ['*all'], "maxResults": 1000, "startAt": startAt});
-    collectedIssues.push(...response.issues);
+    let issues = response.issues;
+    if (JIRA.RETRIEVE_WATCHERS) {
+      issues = await Promise.all(response.issues.map( async (issue) => {
+        let watchesUrl = issue.fields.watches.self;
+        let watchesResponse = await jira.doRequest(jira.makeRequestHeader(watchesUrl));
+        issue.fields.watchers = watchesResponse.watchers;
+        return issue
+      }));
+    }
+    collectedIssues.push(...issues);
     console.log(`downloaded ${collectedIssues.length} / ${response.total} issues`);
     if (collectedIssues.length >= response.total) {
       break;

--- a/src/jira/jira-types.ts
+++ b/src/jira/jira-types.ts
@@ -71,7 +71,8 @@ export interface JiraBaseFields {
   };
   issuelinks: null | IssueLink[],
   parent?: JiraRegularIssue;
-  attachment: Attachment[]
+  attachment: Attachment[],
+  watchers: null | User[]
 }
 
 


### PR DESCRIPTION
NOTE: The code creates a watchers field in the issue, and loads the response there. It might be better to simply overwrite the watches object.