### PR TITLE
fix user search

### DIFF
--- a/src/jira/jira-extraction.ts
+++ b/src/jira/jira-extraction.ts
@@ -16,8 +16,11 @@ export const downloadAllProjects = async () => {
 
 export const downloadAllUsers = async () => {
   ensureDataDirExists();
-  const allUsers = await jira.searchUsers({username: "%"});
-  fs.writeFileSync(__dirname + '/../../data/users.json', JSON.stringify(allUsers, undefined, '\t'));
+  const allUsers = await jira.searchUsers({ query: { displayName: "%" } });
+  fs.writeFileSync(
+    __dirname + "/../../data/users.json",
+    JSON.stringify(allUsers, undefined, "\t")
+  );
   console.log(`${allUsers.length} users downloaded`);
 };
 


### PR DESCRIPTION
searching by username is deprecated: https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#api-group-User-search

This searches by `displayName` instead. 